### PR TITLE
Bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ const schema = `
   }
   type Error {
     message: String!
-    zodErrors: [ZodError]
+    zodIssues: [ZodIssue]
   }
   type Query {
-    validatePhrase(input: ObjectToValidate): ZodError
+    validatePhrase(input: ObjectToValidate): Success | Error
   }
 `;
 
@@ -69,7 +69,7 @@ const resolvers = {
         return {
           __typename: "Error",
           message: "Object failed vlaidation.",
-          zodErrors: zodErrorsTozodIssues(error),
+          zodIssues: zodErrorsTozodIssues(error),
         };
       }
     },

--- a/index.ts
+++ b/index.ts
@@ -4,6 +4,7 @@ import type { ZodError, ZodIssue } from "zod";
 export const zodTypeDef = `
   scalar StringNumber
   scalar ZodParsedType
+  scalar ZodIssueCode
   enum ZodValidation {
     url
     email
@@ -13,20 +14,6 @@ export const zodTypeDef = `
     string
     number
     array
-  }
-  enum ZodIssueCode {
-    invalid_type
-    unrecognized_keys
-    invalid_union
-    invalid_enum_value
-    invalid_arguments
-    invalid_return_type
-    invalid_date
-    invalid_string
-    too_small
-    too_big
-    not_multiple_of
-    custom
   }
   type ZodUnionIssue {
     code: ZodIssueCode!
@@ -95,6 +82,41 @@ const StringNumber = new GraphQLScalarType({
   parseLiteral: stringNumber,
 });
 
+export const issueCodes: Set<string> = new Set([
+  "invalid_type",
+  "unrecognized_keys",
+  "invalid_union",
+  "invalid_enum_value",
+  "invalid_arguments",
+  "invalid_return_type",
+  "invalid_date",
+  "invalid_string",
+  "too_small",
+  "too_big",
+  "not_multiple_of",
+  "custom",
+]);
+
+const ZodIssueCode = new GraphQLScalarType({
+  name: "ZodIssueCode",
+  description: "const enum for zod issue codes",
+  serialize: validateZodIssueCode,
+  parseValue: validateZodIssueCode,
+  parseLiteral: validateZodIssueCode,
+});
+
+export function validateZodIssueCode(value: unknown) {
+  if (typeof value !== "string") {
+    throw new Error("Provided value must be a string.");
+  }
+  if (!issueCodes.has(value)) {
+    throw new Error(
+      `Provided value is not one of ${Array.from(issueCodes).join(", ")}`
+    );
+  }
+  return value;
+}
+
 export function zodParsedType(value: unknown) {
   if (typeof value !== "string") {
     throw new Error("Provided value must be a string.");
@@ -137,4 +159,4 @@ export function zodErrorsTozodIssues(zodError: ZodError) {
   });
 }
 
-export const scalars = { StringNumber, ZodParsedType };
+export const zodErrorScalars = { StringNumber, ZodParsedType, ZodIssueCode };

--- a/test/fastify.ts
+++ b/test/fastify.ts
@@ -3,7 +3,7 @@ import { fastify as Fastify, FastifyServerOptions } from "fastify";
 import mercurius from "mercurius";
 import { makeExecutableSchema } from "@graphql-tools/schema";
 import { codegenMercurius } from "mercurius-codegen";
-import { zodTypeDef, scalars } from "../index.js";
+import { zodTypeDef, zodErrorScalars } from "../index.js";
 import { checkSchemaResolver, checkSchemaTypeDef } from "./check-schema.js";
 import { GraphQLScalarType } from "graphql";
 
@@ -27,7 +27,7 @@ export async function fastify(options: FastifyServerOptions = {}) {
 
   const resolvers = {
     AnyType,
-    ...scalars,
+    ...zodErrorScalars,
     Query: {
       ...checkSchemaResolver,
     },
@@ -41,7 +41,7 @@ export async function fastify(options: FastifyServerOptions = {}) {
     graphiql: true,
   });
 
-  if (process.env.NODE_ENV !== "test") {
+  if (process.env["NODE_ENV"] !== "test") {
     await codegenMercurius(fastify, {
       targetPath: "./types/graphql/generated.ts",
       silent: false,

--- a/test/graphql-tests.test.ts
+++ b/test/graphql-tests.test.ts
@@ -1,12 +1,8 @@
 import { describe, expect, test } from "vitest";
 import { createMercuriusTestClient } from "mercurius-integration-testing";
 import { fastify as Fastify } from "./fastify.js";
-import {
-  ZodIssueCode,
-  ZodType,
-  checkSchemaDocument,
-} from "../types/graphql/generated.js";
-import { ZodParsedType } from "zod";
+import { ZodType, checkSchemaDocument } from "../types/graphql/generated.js";
+import { ZodIssueCode, ZodParsedType } from "zod";
 
 describe.concurrent("Test suite", async () => {
   const fastify = await Fastify();

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { ZodError, z } from "zod";
 import {
+  validateZodIssueCode,
   zodParsedType,
   zodParsedTypes,
   stringNumber,
@@ -8,6 +9,16 @@ import {
 } from "../index";
 
 describe.concurrent("index.ts suite", () => {
+  test("validateZodIssueCode", () => {
+    expect(validateZodIssueCode("invalid_type")).toEqual("invalid_type");
+    expect(() => {
+      validateZodIssueCode("not_valid");
+    }).toThrow();
+    expect(() => {
+      validateZodIssueCode(1);
+    }).toThrowError("Provided value must be a string.");
+  });
+
   test("zodParsedType", () => {
     // Happy path
     expect(zodParsedType("string")).toEqual("string");

--- a/types/graphql/generated.ts
+++ b/types/graphql/generated.ts
@@ -35,6 +35,8 @@ export type Scalars = {
   StringNumber: any;
   /** This is an enum used by Zod internally to represent the type of a parsed value. */
   ZodParsedType: any;
+  /** const enum for zod issue codes */
+  ZodIssueCode: any;
   /** Accepts any type. */
   AnyType: any;
   _FieldSet: any;
@@ -52,24 +54,9 @@ export enum ZodType {
   array = "array",
 }
 
-export enum ZodIssueCode {
-  invalid_type = "invalid_type",
-  unrecognized_keys = "unrecognized_keys",
-  invalid_union = "invalid_union",
-  invalid_enum_value = "invalid_enum_value",
-  invalid_arguments = "invalid_arguments",
-  invalid_return_type = "invalid_return_type",
-  invalid_date = "invalid_date",
-  invalid_string = "invalid_string",
-  too_small = "too_small",
-  too_big = "too_big",
-  not_multiple_of = "not_multiple_of",
-  custom = "custom",
-}
-
 export type ZodUnionIssue = {
   __typename?: "ZodUnionIssue";
-  code: ZodIssueCode;
+  code: Scalars["ZodIssueCode"];
   expected?: Maybe<Scalars["ZodParsedType"]>;
   received?: Maybe<Scalars["ZodParsedType"]>;
   path?: Maybe<Array<Maybe<Scalars["StringNumber"]>>>;
@@ -78,7 +65,7 @@ export type ZodUnionIssue = {
 
 export type ZodIssue = {
   __typename?: "ZodIssue";
-  code: ZodIssueCode;
+  code: Scalars["ZodIssueCode"];
   path?: Maybe<Array<Maybe<Scalars["StringNumber"]>>>;
   message: Scalars["String"];
   expected?: Maybe<Scalars["ZodParsedType"]>;
@@ -237,9 +224,9 @@ export type DirectiveResolverFn<
 export type ResolversTypes = {
   StringNumber: ResolverTypeWrapper<Scalars["StringNumber"]>;
   ZodParsedType: ResolverTypeWrapper<Scalars["ZodParsedType"]>;
+  ZodIssueCode: ResolverTypeWrapper<Scalars["ZodIssueCode"]>;
   ZodValidation: ZodValidation;
   ZodType: ZodType;
-  ZodIssueCode: ZodIssueCode;
   ZodUnionIssue: ResolverTypeWrapper<ZodUnionIssue>;
   String: ResolverTypeWrapper<Scalars["String"]>;
   ZodIssue: ResolverTypeWrapper<ZodIssue>;
@@ -257,6 +244,7 @@ export type ResolversTypes = {
 export type ResolversParentTypes = {
   StringNumber: Scalars["StringNumber"];
   ZodParsedType: Scalars["ZodParsedType"];
+  ZodIssueCode: Scalars["ZodIssueCode"];
   ZodUnionIssue: ZodUnionIssue;
   String: Scalars["String"];
   ZodIssue: ZodIssue;
@@ -280,6 +268,11 @@ export interface StringNumberScalarConfig
 export interface ZodParsedTypeScalarConfig
   extends GraphQLScalarTypeConfig<ResolversTypes["ZodParsedType"], any> {
   name: "ZodParsedType";
+}
+
+export interface ZodIssueCodeScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes["ZodIssueCode"], any> {
+  name: "ZodIssueCode";
 }
 
 export type ZodUnionIssueResolvers<
@@ -414,6 +407,7 @@ export type ValidationResultResolvers<
 export type Resolvers<ContextType = MercuriusContext> = {
   StringNumber?: GraphQLScalarType;
   ZodParsedType?: GraphQLScalarType;
+  ZodIssueCode?: GraphQLScalarType;
   ZodUnionIssue?: ZodUnionIssueResolvers<ContextType>;
   ZodIssue?: ZodIssueResolvers<ContextType>;
   AnyType?: GraphQLScalarType;
@@ -446,7 +440,7 @@ export interface Loaders<
   }
 > {
   ZodUnionIssue?: {
-    code?: LoaderResolver<ZodIssueCode, ZodUnionIssue, {}, TContext>;
+    code?: LoaderResolver<Scalars["ZodIssueCode"], ZodUnionIssue, {}, TContext>;
     expected?: LoaderResolver<
       Maybe<Scalars["ZodParsedType"]>,
       ZodUnionIssue,
@@ -469,7 +463,7 @@ export interface Loaders<
   };
 
   ZodIssue?: {
-    code?: LoaderResolver<ZodIssueCode, ZodIssue, {}, TContext>;
+    code?: LoaderResolver<Scalars["ZodIssueCode"], ZodIssue, {}, TContext>;
     path?: LoaderResolver<
       Maybe<Array<Maybe<Scalars["StringNumber"]>>>,
       ZodIssue,
@@ -555,7 +549,7 @@ export type checkSchemaQuery = {
         message: string;
         zodIssues?: Array<{
           __typename?: "ZodIssue";
-          code: ZodIssueCode;
+          code: any;
           message: string;
           path?: Array<any | null> | null;
           expected?: any | null;
@@ -570,7 +564,7 @@ export type checkSchemaQuery = {
           multipleOf?: number | null;
           unionIssues?: Array<Array<{
             __typename?: "ZodUnionIssue";
-            code: ZodIssueCode;
+            code: any;
             expected?: any | null;
             received?: any | null;
             path?: Array<any | null> | null;


### PR DESCRIPTION
# Changes

1. Converted the GraphQL `ZodIssueType` to a type that satisfies the ZodIssueCode Typescript type when it is generated to a TypeScript type with [codegen](https://the-guild.dev/graphql/codegen).
2. Updated docs to reference new `ZodIssue` naming vs. `ZodError` for clarity